### PR TITLE
Add four indent rule [#1]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
         "brace-style": ["warn", "stroustrup", { "allowSingleLine": true }],
         "guard-for-in": ["error"],
         "curly": ["warn"],
-        "prefer-arrow-callback": ["error", {"allowUnboundThis": false}]
+        "prefer-arrow-callback": ["error", {"allowUnboundThis": false}],
+        "indent": ["error", 4]
     }
 }


### PR DESCRIPTION
If indent is not 4 spaces.

```
-    greeting():void{
+  greeting():void{
```
 it' making errors as follows.
```
npm run lint                                          4521  09:22:21 

> typescript-node-jest-eslint-vscode@1.0.0 lint /Users/hkojima/workspace/bumblebee/typescript-node-jest-eslint-vscode
> eslint ./src/*.ts


/Users/hkojima/workspace/bumblebee/typescript-node-jest-eslint-vscode/src/hello.ts
  9:1  error  Expected indentation of 4 spaces but found 2  indent

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! typescript-node-jest-eslint-vscode@1.0.0 lint: `eslint ./src/*.ts`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the typescript-node-jest-eslint-vscode@1.0.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/hkojima/.npm/_logs/2020-06-23T00_22_26_911Z-debug.log
```


VScode also works as follows

<img width="540" alt="スクリーンショット 2020-06-23 9 22 53" src="https://user-images.githubusercontent.com/1008563/85347635-185e9500-b534-11ea-9be2-c96c359c6e40.png">
