### PR TITLE
Add prettier setting [#3]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,10 +3,12 @@
         "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
-        "prettier/@typescript-eslint"
+        "prettier/@typescript-eslint",
+        "prettier"
     ],
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "prettier"
     ],
     "env": { "node": true, "es6": true },
     "parser": "@typescript-eslint/parser",
@@ -20,6 +22,7 @@
         "guard-for-in": ["error"],
         "curly": ["warn"],
         "prefer-arrow-callback": ["error", {"allowUnboundThis": false}],
-        "indent": ["error", 4]
+        "indent": ["error", 4],
+        "prettier/prettier": "error"
     }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 4
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,18 +1949,18 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@typescript-eslint/eslint-plugin": "^2.21.0",
     "@typescript-eslint/parser": "^2.21.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "jest": "^25.1.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.1",
@@ -35,7 +35,7 @@
   "author": "komasayuki",
   "license": "MIT",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/komasayuki/typescript-node-jest-eslint-vscode.git"
+    "type": "git",
+    "url": "https://github.com/komasayuki/typescript-node-jest-eslint-vscode.git"
   }
 }

--- a/src/hello.ts
+++ b/src/hello.ts
@@ -1,17 +1,15 @@
-export class Hello{
+export class Hello {
+    private name: string;
 
-    private name:string;
-
-    constructor(name:string){
+    constructor(name: string) {
         this.name = name;
     }
 
-    greeting():void{
+    greeting(): void {
         console.log('Hello', this.name);
     }
 
-    getName():string{
+    getName(): string {
         return this.name;
     }
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Hello} from './hello'
+import { Hello } from './hello';
 
 const hello = new Hello('World');
 hello.greeting();


### PR DESCRIPTION
This PR is related with #3 .

If we use prettier from editor like vscode,
we can automatically, format with same rule as eslint.

,and some indent automation also added based on prettier default options.
I change the format fo below files by using prettier. Please check it.
- src/index.ts
- src/hello.ts

